### PR TITLE
Fixed name in German typo

### DIFF
--- a/webapp/titanembeds/constants.py
+++ b/webapp/titanembeds/constants.py
@@ -118,7 +118,7 @@ LANGUAGES = [
     {
         "code": "de_DE",
         "name_en": "German",
-        "name": "Deutsche",
+        "name": "Deutsch",
         "translators": [
             {
                 "name": "futureyess22",


### PR DESCRIPTION
"Deutsche" means "germans", but speaking of the language, it's just "Deutsch".