### PR TITLE
fixing a typo and minor nits for better cookie security

### DIFF
--- a/webapp/alembic/versions/2a2f32ac91d6_added_titan_tokens.py
+++ b/webapp/alembic/versions/2a2f32ac91d6_added_titan_tokens.py
@@ -133,7 +133,7 @@ def downgrade():
                existing_nullable=False,
                existing_server_default=sa.text(u"'1'"))
     op.alter_column(u'guilds', 'channels',
-               existing_typesa.Text().with_variant(sa.Text(length=4294967295), 'mysql'),
+               existing_type=sa.Text().with_variant(sa.Text(length=4294967295), 'mysql'),
                type_=mysql.LONGTEXT(collation=u'utf8mb4_unicode_ci'),
                existing_nullable=False)
     op.alter_column(u'guilds', 'bracket_links',

--- a/webapp/titanembeds/blueprints/embed/embed.py
+++ b/webapp/titanembeds/blueprints/embed/embed.py
@@ -118,7 +118,7 @@ def noscript():
 def cookietest1():
     js = "window._3rd_party_test_step1_loaded();"
     response = make_response(js, 200, {'Content-Type': 'application/javascript'})
-    response.set_cookie('third_party_c_t', "works", max_age=30)
+    response.set_cookie('third_party_c_t', "works", max_age=30, secure=True, httponly=True, samesite='Lax')
     return response
 
 @embed.route("/cookietest2")
@@ -130,5 +130,5 @@ def cookietest2():
         js = js + "false"
     js = js + ");"
     response = make_response(js, 200, {'Content-Type': 'application/javascript'})
-    response.set_cookie('third_party_c_t', "", expires=0)
+    response.set_cookie('third_party_c_t', "", expires=0,secure=True, httponly=True, samesite='Lax')
     return response


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python 3 web projects, called Bento. While we were scanning GitHub Flask projects for issues, it triggered a warning for the set_cookie method in your app. 

Looks like you use cookies for testing the third party app integration, so there is no real issue here. That said, there is no harm in setting the `secure`, `httponly` and `samesite` parameters, per Flask best practices. (https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options)

Bento also spotted a typo, which I fixed. 

The more important point is that Bento also complains about the way you use templates. By default, in Flask, if a template ends with `.html`, `.htm`, `.xml`,m or  `.xhtml`, it will be auto-escaped but otherwise it won't. In your case, the templates end with a `.j2` pattern (ex: about.html.j2), so your templates are not auto-escaped. If any of the request parameters for those routes end up flowing into the template variables, an attacker may be able to create an XSS vulnerability. You can read more about it here: https://checks.bento.dev/en/latest/flake8-flask/unescaped-file-extension/. 

You can review these issues yourself by downloading bento from https://bento.dev/