### PR TITLE
Colour fix for large buttons in FireWyvern

### DIFF
--- a/webapp/titanembeds/static/themes/FireWyvern/css/style.css
+++ b/webapp/titanembeds/static/themes/FireWyvern/css/style.css
@@ -25,7 +25,7 @@ background-color: rgb(255,95,20);
 .btn:visited{
 background-color: rgb(255,95,20);
 }
-.btn:hover {
+.btn:hover, .btn-large:hover {
 background-color: orange
 }
 .btn:active{


### PR DESCRIPTION
Fixed an issue where large buttons would not display the correct colour when being hovered over in the FireWyvern theme.