### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,7 @@ flask-redis
 sqlalchemy
 asyncio_redis
 raven[flask]
-Werkzeug>=1.0.0
+Werkzeug==2.0.3
 yarl==1.4.2
+eventlet
+async-timeout==3.0


### PR DESCRIPTION
- Werkzeug 2.1 not compatible with Flask-SocketIO 4.3.2
- async-timeout > 3.0 not compatible with aiohttp 3.7.4
- eventlet install by default (ig the only mode supported by websocket for project?)